### PR TITLE
Add Azure file storage mount to app container

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -218,8 +218,25 @@ resource "azurerm_container_app" "main" {
       image  = "${azurerm_container_registry.main.login_server}/${local.container_app.name}:latest"
       cpu    = "0.5"
       memory = "1.0Gi"
+
+      volume_mounts {
+        name = "azure-files-volume"
+        mount_path = var.container_mount_path
+      }
     }
 
+    volume {
+      name = "azure-files-volume"
+      storage_type = "AzureFile"
+      storage_name = "azure-files-storage"
+    }
+  }
+
+  storage {
+    name = "azure-files-storage"
+    storage_account_name = azurerm_storage_account.main.name
+    storage_account_key = azurerm_storage_account.main.primary_access_key
+    share_name = var.storage_share_name
   }
 
   tags = local.tags

--- a/variables.tf
+++ b/variables.tf
@@ -52,3 +52,15 @@ variable "subscription_id" {
   description = "The Azure subscription ID."
   type        = string
 }
+
+variable "storage_share_name" {
+  description = "The name of the Azure Files share."
+  type        = string
+  default     = "app-files"
+}
+
+variable "container_mount_path" {
+  description = "The path where the Azure Files share will be mounted in the container."
+  type        = string
+  default     = "/mnt/files"
+}


### PR DESCRIPTION
Introduce a file storage mount to the app container, allowing the Azure Files share to be mounted at a specified path within the container. This includes new variables for the storage share name and mount path.